### PR TITLE
fix: outbound flow

### DIFF
--- a/app/components/requester_form_component.html.erb
+++ b/app/components/requester_form_component.html.erb
@@ -1,4 +1,6 @@
 <%= form_with(url: @url, class: "requester-form") do |form| %>
+  <%= form.hidden_field :regulation, value: params[:regulation] %>
+
   <div class="requester-form__primary">
     <div class="requester-form__field">
       <%=

--- a/app/controllers/bulk_deletion_requests_controller.rb
+++ b/app/controllers/bulk_deletion_requests_controller.rb
@@ -20,6 +20,8 @@ class BulkDeletionRequestsController < ApplicationController
       render(:new, status: :unprocessable_entity) && return
     end
 
-    redirect_to root_path, notice: t(".notice")
+    redirect_to \
+      new_bulk_deletion_request_path(regulation: params[:regulation]),
+      notice: t(".notice")
   end
 end

--- a/app/models/bulk_deletion_request.rb
+++ b/app/models/bulk_deletion_request.rb
@@ -40,11 +40,11 @@ class BulkDeletionRequest
 
   private
 
-  # Generate a deletion request email for each California data brokers.
+  # Generate a deletion request email for each company.
   #
   # @return [void]
   def generate_emails
-    Company.california_data_brokers.find_each.with_index do |company, index|
+    Company.all.find_each.with_index do |company, index|
       deletion_request = DeletionRequest.new \
         company: company,
         smtp_config: smtp_config,

--- a/test/integration/deletion_request_flows_test.rb
+++ b/test/integration/deletion_request_flows_test.rb
@@ -21,7 +21,7 @@ class DeletionRequestFlowsTest < ActionDispatch::IntegrationTest
     # is correct.
     assert_emails 1
     assert_enqueued_emails 1
-    assert_redirected_to root_path
+    assert_redirected_to new_bulk_deletion_request_path
     assert_equal "Deletion requests being sent through your SMTP provider. Check your email outbox for confirmation.", flash[:notice]
 
     # The rest of the emails should be able to be delivered later.


### PR DESCRIPTION
# Overview

There was an issue where a successful form submission would render a page that stated a translation was missing. This was due to the redirect going to the wrong path. It was pointing at the root path when I was building the proof of concept, but it has since changed the target path.

This also makes it so that all companies in the database get emailed rather than just California data brokers.