### PR TITLE
feat: support custom SMTP hosts

### DIFF
--- a/app/assets/stylesheets/2-components/requester-form.css
+++ b/app/assets/stylesheets/2-components/requester-form.css
@@ -67,6 +67,16 @@
   display: flex;
   flex-direction: column;
   gap: var(--spacing-xs);
+
+  &:has([name="smtp_host"]),
+  &:has([name="smtp_port"]) {
+    display: none;
+  }
+
+  :has([value="other"]:checked)
+  &:has(:is([name="smtp_host"], [name="smtp_port"])) {
+    display: flex;
+  }
 }
 
 .requester-form__label {

--- a/app/components/requester_form_component.html.erb
+++ b/app/components/requester_form_component.html.erb
@@ -62,6 +62,41 @@
       <div class="requester-form__field">
         <%=
           form.label(
+            :smtp_host,
+            t("components.requester_form.smtp_host_label"),
+            class: "requester-form__label"
+          )
+        %>
+        <%=
+          form.text_field(
+            :smtp_host,
+            placeholder: "smtp.email.provider",
+            value: smtp_host_value,
+            class: "requester-form__input"
+          )
+        %>
+      </div>
+
+      <div class="requester-form__field">
+        <%=
+          form.label(
+            :smtp_port,
+            t("components.requester_form.smtp_port_label"),
+            class: "requester-form__label"
+          )
+        %>
+        <%=
+          form.text_field(
+            :smtp_port,
+            value: smtp_port_value,
+            class: "requester-form__input"
+          )
+        %>
+      </div>
+
+      <div class="requester-form__field">
+        <%=
+          form.label(
             :smtp_username,
             t("components.requester_form.smtp_username_label"),
             class: "requester-form__label"

--- a/app/components/requester_form_component.rb
+++ b/app/components/requester_form_component.rb
@@ -47,7 +47,9 @@ class RequesterFormComponent < ApplicationComponent
   #
   # @return [Array<String, String>]
   def smtp_provider_options
-    SmtpConfig::PROVIDERS.map { |key, value| [value[:label], key] }
+    supported_provider_options =
+      SmtpConfig::PROVIDERS.map { |key, value| [value[:label], key] }
+    supported_provider_options << [I18n.t("components.requester_form.smtp_other_provider"), "other"]
   end
 
   # Gives the SMTP provider field's selected value.
@@ -57,6 +59,20 @@ class RequesterFormComponent < ApplicationComponent
     retained_value = @bulk_deletion_request&.params&.dig("smtp_provider")
     first_provider = SmtpConfig::PROVIDERS.keys.first
     retained_value || first_provider
+  end
+
+  # Gives the SMTP host field's value, if any.
+  #
+  # @return [String, nil]
+  def smtp_host_value
+    @bulk_deletion_request&.params&.dig("smtp_host")
+  end
+
+  # Gives the SMTP port field's value, if any.
+  #
+  # @return [String, nil]
+  def smtp_port_value
+    @bulk_deletion_request&.params&.dig("smtp_port")
   end
 
   # Gives the SMTP provider field's value, if any.

--- a/app/mailers/deletion_request_mailer.rb
+++ b/app/mailers/deletion_request_mailer.rb
@@ -10,7 +10,7 @@ class DeletionRequestMailer < ApplicationMailer
       user_name: @deletion_request.smtp_config.username,
       password: @deletion_request.smtp_config.password,
       address: @deletion_request.smtp_config.address,
-      port: @deletion_request.smtp_config.port,
+      port: @deletion_request.smtp_config.provider_port,
       authentication: @deletion_request.smtp_config.authentication
     }
 

--- a/app/models/bulk_deletion_request.rb
+++ b/app/models/bulk_deletion_request.rb
@@ -67,6 +67,8 @@ class BulkDeletionRequest
   def smtp_config
     @_smtp_config ||= SmtpConfig.new \
       provider: @params[:smtp_provider],
+      host: @params[:smtp_host],
+      port: @params[:smtp_port],
       username: @params[:smtp_username],
       password: @params[:smtp_password]
   end

--- a/app/models/concerns/smtp_config/providers_supportable.rb
+++ b/app/models/concerns/smtp_config/providers_supportable.rb
@@ -44,14 +44,14 @@ module SmtpConfig::ProvidersSupportable
   #
   # @return [String]
   def address
-    PROVIDERS.dig(provider.to_sym, :address)
+    host || PROVIDERS.dig(provider.to_sym, :address)
   end
 
   # Returns the port of the SMTP provider.
   #
   # @return [Integer]
-  def port
-    PROVIDERS.dig(provider.to_sym, :port)
+  def provider_port
+    port || PROVIDERS.dig(provider.to_sym, :port)
   end
 
   # Returns the authentication method of the SMTP provider.

--- a/app/models/smtp_config.rb
+++ b/app/models/smtp_config.rb
@@ -6,10 +6,13 @@ class SmtpConfig
   include ProvidersSupportable
 
   attribute :provider, :string
+  attribute :host, :string
+  attribute :port, :integer
   attribute :username, :string
   attribute :password, :string
 
-  validates :provider, inclusion: {in: PROVIDERS.keys.map(&:to_s)}
+  validates :provider, inclusion: {in: PROVIDERS.keys.push(:other).map(&:to_s)}
+  validates :host, :port, presence: true, if: -> { provider == "other" }
   validates :username, :password, presence: true
 
   # To support `ActiveModel::Serialization`.
@@ -18,6 +21,8 @@ class SmtpConfig
   def attributes
     {
       "provider" => nil,
+      "host" => nil,
+      "port" => nil,
       "username" => nil,
       "password" => nil
     }

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -36,8 +36,11 @@ en:
 
     requester_form:
       smtp_provider_label: "SMTP provider"
+      smtp_host_label: "SMTP host"
+      smtp_port_label: "SMTP port"
       smtp_username_label: "SMTP username"
       smtp_password_label: "SMTP password"
+      smtp_other_provider: "Other"
       email_subject_label: "Email subject"
       email_subject_value: "Personal information deletion request"
       email_body_label: "Email body"

--- a/test/integration/data_sync_flows_test.rb
+++ b/test/integration/data_sync_flows_test.rb
@@ -1,3 +1,5 @@
+require "test_helper"
+
 class DataSyncFlowsTest < ActionDispatch::IntegrationTest
   test "CPPA data brokers syncable" do
     assert_equal 1, Company.count # We start off with one fixture

--- a/test/integration/deletion_request_flows_test.rb
+++ b/test/integration/deletion_request_flows_test.rb
@@ -1,3 +1,5 @@
+require "test_helper"
+
 class DeletionRequestFlowsTest < ActionDispatch::IntegrationTest
   test "able to deliver emails for a valid bulk deletion request" do
     # Creating an extra California data broker company separate from fixtures.
@@ -27,6 +29,24 @@ class DeletionRequestFlowsTest < ActionDispatch::IntegrationTest
     # The rest of the emails should be able to be delivered later.
     perform_enqueued_jobs
     assert_emails 2
+  end
+
+  test "able to deliver emails for a valid bulk deletion request with other provider" do
+    post \
+      bulk_deletion_requests_path,
+      params: {
+        email_subject: "Test deletion request subject",
+        email_body: "Test deletion request body",
+        smtp_provider: "other",
+        smtp_host: "smtp.localhost",
+        smtp_port: 587,
+        smtp_username: "test_username",
+        smtp_password: "test_password"
+      }
+
+    assert_emails 1
+    assert_redirected_to new_bulk_deletion_request_path
+    assert_equal "Deletion requests being sent through your SMTP provider. Check your email outbox for confirmation.", flash[:notice]
   end
 
   # It's possible for multiple companies to have the same contact email address

--- a/test/integration/smoke_test.rb
+++ b/test/integration/smoke_test.rb
@@ -1,3 +1,5 @@
+require "test_helper"
+
 class SmokeTest < ActionDispatch::IntegrationTest
   test "home page" do
     get "/"

--- a/test/models/company_test.rb
+++ b/test/models/company_test.rb
@@ -15,6 +15,8 @@
 #  index_companies_on_category  (category)
 #  index_companies_on_website   (website) UNIQUE
 #
+require "test_helper"
+
 class CompanyTest < ActiveSupport::TestCase
   test "valid object" do
     company = Company.new \

--- a/test/models/deletion_request_test.rb
+++ b/test/models/deletion_request_test.rb
@@ -1,3 +1,5 @@
+require "test_helper"
+
 class DeletionRequestTest < ActiveSupport::TestCase
   test "valid object" do
     smtp_config = SmtpConfig.new \

--- a/test/models/smtp_config_test.rb
+++ b/test/models/smtp_config_test.rb
@@ -1,3 +1,5 @@
+require "test_helper"
+
 class SmtpConfigTest < ActiveSupport::TestCase
   test "valid object" do
     smtp_config = SmtpConfig.new \
@@ -8,9 +10,40 @@ class SmtpConfigTest < ActiveSupport::TestCase
     assert smtp_config.valid?
   end
 
+  test "valid object with other provider" do
+    smtp_config = SmtpConfig.new \
+      provider: "other",
+      host: "smtp.localhost",
+      port: 587,
+      username: "test_username",
+      password: "test_password"
+
+    assert smtp_config.valid?
+  end
+
   test "invalid without a valid provider" do
     smtp_config = SmtpConfig.new \
       provider: "invalid_provider",
+      username: "test_username",
+      password: "test_password"
+
+    assert smtp_config.invalid?
+  end
+
+  test "invalid without host for other provider" do
+    smtp_config = SmtpConfig.new \
+      provider: "other",
+      port: 587,
+      username: "test_username",
+      password: "test_password"
+
+    assert smtp_config.invalid?
+  end
+
+  test "invalid without port for other provider" do
+    smtp_config = SmtpConfig.new \
+      provider: "other",
+      host: "smtp.localhost",
       username: "test_username",
       password: "test_password"
 
@@ -33,7 +66,7 @@ class SmtpConfigTest < ActiveSupport::TestCase
     assert smtp_config.invalid?
   end
 
-  test "#address" do
+  test "#address returns correct value for standard provider" do
     smtp_config = SmtpConfig.new \
       provider: "gmail",
       username: "test_username",
@@ -42,12 +75,34 @@ class SmtpConfigTest < ActiveSupport::TestCase
     assert_equal "smtp.gmail.com", smtp_config.address
   end
 
-  test "#port" do
+  test "#address returns correct value for other provider" do
+    smtp_config = SmtpConfig.new \
+      provider: "other",
+      host: "smtp.localhost",
+      port: 123,
+      username: "test_username",
+      password: "test_password"
+
+    assert_equal "smtp.localhost", smtp_config.address
+  end
+
+  test "#provider_port returns correct value for standard provider" do
     smtp_config = SmtpConfig.new \
       provider: "gmail",
       username: "test_username",
       password: "test_password"
 
-    assert_equal 587, smtp_config.port
+    assert_equal 587, smtp_config.provider_port
+  end
+
+  test "#provider_port returns correct value for other provider" do
+    smtp_config = SmtpConfig.new \
+      provider: "other",
+      host: "smtp.localhost",
+      port: 123,
+      username: "test_username",
+      password: "test_password"
+
+    assert_equal 123, smtp_config.provider_port
   end
 end


### PR DESCRIPTION
# Issue

Closes #10.

# Overview

As the title states, this PR enables custom SMTP hosts/ports for users that have a provider outside of the standard list. A new "Other" option is added to the SMTP provider dropdown in the deletion request form, and selecting it will show new host and port fields that users can manually input.

# Screenshot

![image](https://github.com/nshki/naisho/assets/1121087/4faad25e-6117-4d2a-ad49-2b7ca0f7cd97)