### PR TITLE
chore: only call `Company#update` when new data present

### DIFF
--- a/app/models/concerns/company/california_data_brokers_requestable.rb
+++ b/app/models/concerns/company/california_data_brokers_requestable.rb
@@ -24,10 +24,12 @@ module Company::CaliforniaDataBrokersRequestable
         next if email.blank? || name.blank? || website.blank?
 
         company = Company.find_or_initialize_by(email: email)
-        company.update \
-          category: Company::CATEGORIES[:california_data_broker],
-          name: name,
-          website: website
+        if company.name != name || company.website != website
+          company.update \
+            category: Company::CATEGORIES[:california_data_broker],
+            name: name,
+            website: website
+        end
       rescue ActiveRecord::RecordNotUnique
       end
     end

--- a/app/models/concerns/company/data_brokers_watch_requestable.rb
+++ b/app/models/concerns/company/data_brokers_watch_requestable.rb
@@ -26,10 +26,12 @@ module Company::DataBrokersWatchRequestable
         next if email.blank? || name.blank? || website.blank?
 
         company = Company.find_or_initialize_by(email: email)
-        company.update \
-          category: Company::CATEGORIES[:data_brokers_watch],
-          name: name,
-          website: website
+        if company.name != name || company.website != website
+          company.update \
+            category: Company::CATEGORIES[:data_brokers_watch],
+            name: name,
+            website: website
+        end
       rescue ActiveRecord::RecordNotUnique
       end
     end


### PR DESCRIPTION
# Overview

This is a minor PR where we only make a call out to `Company#update` in each company source's concern when new data is present. This is mainly to prevent the `/companies` page from displaying a new timestamp if nothing was genuinely updated after a sync.