### PR TITLE
fix: broken sends

### DIFF
--- a/app/models/concerns/smtp_config/providers_supportable.rb
+++ b/app/models/concerns/smtp_config/providers_supportable.rb
@@ -44,14 +44,14 @@ module SmtpConfig::ProvidersSupportable
   #
   # @return [String]
   def address
-    host || PROVIDERS.dig(provider.to_sym, :address)
+    host.present? ? host : PROVIDERS.dig(provider.to_sym, :address)
   end
 
   # Returns the port of the SMTP provider.
   #
   # @return [Integer]
   def provider_port
-    port || PROVIDERS.dig(provider.to_sym, :port)
+    port.present? ? port : PROVIDERS.dig(provider.to_sym, :port)
   end
 
   # Returns the authentication method of the SMTP provider.

--- a/test/models/smtp_config_test.rb
+++ b/test/models/smtp_config_test.rb
@@ -70,7 +70,8 @@ class SmtpConfigTest < ActiveSupport::TestCase
     smtp_config = SmtpConfig.new \
       provider: "gmail",
       username: "test_username",
-      password: "test_password"
+      password: "test_password",
+      host: ""
 
     assert_equal "smtp.gmail.com", smtp_config.address
   end
@@ -90,7 +91,8 @@ class SmtpConfigTest < ActiveSupport::TestCase
     smtp_config = SmtpConfig.new \
       provider: "gmail",
       username: "test_username",
-      password: "test_password"
+      password: "test_password",
+      port: ""
 
     assert_equal 587, smtp_config.provider_port
   end


### PR DESCRIPTION
# Overview

Follow-up from #10. The methods that return the SMTP host and port were written in a way that would return empty strings for non-custom SMTP configs, which was not right. This corrects that mistake.