### PR TITLE
fix: form errors

### DIFF
--- a/app/assets/stylesheets/2-components/requester-form.css
+++ b/app/assets/stylesheets/2-components/requester-form.css
@@ -112,10 +112,12 @@
   }
 }
 
-ul.requester-form__flash {
+.requester-form__flash--alert {
   --color-background: #ff000033;
   --color-border: #ff0000;
+}
 
+ul.requester-form__flash {
   padding-left: var(--spacing-lg);
   list-style: square;
 }

--- a/app/components/requester_form_component.html.erb
+++ b/app/components/requester_form_component.html.erb
@@ -131,11 +131,15 @@
 
       <% if show_flash? %>
         <% if errors? %>
-          <ul class="requester-form__flash">
+          <ul class="requester-form__flash requester-form__flash--alert">
             <% errors.each do |error| %>
               <li><%= error %></li>
             <% end %>
           </ul>
+        <% elsif error? %>
+          <p class="requester-form__flash requester-form__flash--alert">
+            <%= errors %>
+          </p>
         <% else %>
           <p class="requester-form__flash"><%= flash_message %></p>
         <% end %>

--- a/app/components/requester_form_component.rb
+++ b/app/components/requester_form_component.rb
@@ -96,11 +96,18 @@ class RequesterFormComponent < ApplicationComponent
     @flash[:notice]
   end
 
+  # Determines if the flash is an error.
+  #
+  # @return [Boolean]
+  def error?
+    @flash[:alert].present?
+  end
+
   # Determines if the flash has errors.
   #
   # @return [Boolean]
   def errors?
-    @flash[:alert].present? && @flash[:alert].is_a?(Array)
+    @flash[:alert].is_a?(Array)
   end
 
   # Fetches errors from the flash.

--- a/app/controllers/bulk_deletion_requests_controller.rb
+++ b/app/controllers/bulk_deletion_requests_controller.rb
@@ -15,7 +15,7 @@ class BulkDeletionRequestsController < ApplicationController
 
     begin
       @bulk_deletion_request.deliver_emails
-    rescue Net::SMTPAuthenticationError
+    rescue
       flash.now[:alert] = t(".smtp_authentication_alert")
       render(:new, status: :unprocessable_entity) && return
     end


### PR DESCRIPTION
# Overview

This fixes the alerts logic in `RequesterFormComponent` since there was a bug with rendering a single error on the page. Before, we were only checking for multiple errors before rendering an unordered list. Now, we'll render a list of errors, a paragraph for a non-array error, and a regular paragraph for a notice.