### PR TITLE
feat: explain limited residency

### DIFF
--- a/app/assets/stylesheets/1-config/base.css
+++ b/app/assets/stylesheets/1-config/base.css
@@ -24,6 +24,10 @@ p, h1, h2, h3, h4, h5, h6, ul, ol {
   margin: 0;
 }
 
+small {
+  font-size: 0.875em;
+}
+
 img, svg {
   max-width: 100%;
   height: auto;

--- a/app/assets/stylesheets/1-config/utilities.css
+++ b/app/assets/stylesheets/1-config/utilities.css
@@ -1,3 +1,20 @@
 .mt-sm {
   margin-top: var(--spacing-sm);
 }
+
+.link {
+  --color-background: transparent;
+  --color-text: var(--color-water);
+
+  background: var(--color-background);
+  appearance: none;
+  border: none;
+  outline: none;
+  text-decoration: underline;
+  color: var(--color-text);
+  cursor: pointer;
+}
+
+.text-center {
+  text-align: center;
+}

--- a/app/assets/stylesheets/2-components/info-modal.css
+++ b/app/assets/stylesheets/2-components/info-modal.css
@@ -21,12 +21,6 @@
     background: var(--color-background);
     backdrop-filter: blur(2px);
   }
-
-  a {
-    --color-text: var(--color-water);
-
-    color: var(--color-text);
-  }
 }
 
 .info-modal__inner {

--- a/app/components/requester_form_component.html.erb
+++ b/app/components/requester_form_component.html.erb
@@ -183,7 +183,13 @@
     <ul>
       <% providers.each do |provider| %>
         <li>
-          <%= link_to provider[:label], provider[:app_password_article_url] %>
+          <%=
+            link_to(
+              provider[:label],
+              provider[:app_password_article_url],
+              class: "link"
+            )
+          %>
         </li>
       <% end %>
     </ul>

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -19,5 +19,22 @@
 
       <%= render(ButtonComponent.new(text: t(".hero.button"), type: "submit", name: nil)) %>
     <% end %>
+
+    <p>
+      <small>
+        <button class="link" popovertarget="no-region-modal">
+          <%= t(".hero.no_region") %>
+        </button>
+      </small>
+    </p>
+  <% end %>
+<% end %>
+
+<%= render InfoModalComponent.new(id: "no-region-modal") do |component| %>
+  <% t(".no_region_modal").each do |section| %>
+    <% component.with_section do %>
+      <h2><%= section[:heading] %></h2>
+      <p><%= section[:paragraph] %></p>
+    <% end %>
   <% end %>
 <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -122,6 +122,11 @@ en:
         region: "I'm a resident of"
         region_placeholder: "Choose..."
         button: "Get started"
+        no_region: "Why don't I see my region here?"
+
+      no_region_modal:
+        - heading: "Why don't I see my region here?"
+          paragraph: "Naisho aims to be available for all regions with strong data privacy laws. If you don't see your region listed and believe it should be, please open an issue or pull request on GitHub."
 
     about:
       title: "About"


### PR DESCRIPTION
# Issue

Closes #11.

# Overview

This adds a popover on the homepage explaining the limited residency list in the main CTA dropdown.

# Screenshots

![image](https://github.com/nshki/naisho/assets/1121087/91c83e31-d557-4ce6-b7ec-21bfdd6be01c)

![image](https://github.com/nshki/naisho/assets/1121087/15a8959e-ecc5-4c9f-b51a-e93e4968e8f7)