### PR TITLE
fix: dead jobs

### DIFF
--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,4 +1,3 @@
 class ApplicationMailer < ActionMailer::Base
-  default from: "from@example.com"
   layout "mailer"
 end

--- a/config/litejob.yml
+++ b/config/litejob.yml
@@ -1,0 +1,3 @@
+retries: 5
+retry_delay: 43200          # 12 hours = 60 seconds * 60 * 12 = 43200 seconds
+retry_delay_multiplier: 2   # 12 hours -> one day -> two days, etc.


### PR DESCRIPTION
# Issue

Closes #22.

# Overview

Before, we were just running on Litejob's retry defaults, which were far too short to account for email platform rate limits. This ensures jobs will get retried up to 5 times with incremental delays at 12 hours, 24 hours, 48 hours, 96 hours, and 192 hours.