### PR TITLE
feat(data): refresh data brokers daily

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,5 +15,5 @@ Naisho is a free and open-source tool for sending personal information data dele
 2. Install [Ruby](https://www.ruby-lang.org/en/) v3.3.6.
 3. Install [SQLite3](https://www.sqlite.org/index.html).
 4. Run `bin/setup` to install Ruby dependencies and set up the database.
-5. Run `bin/rake sync_companies` to pull the latest data broker companies from sources.
+5. Run `bin/rails runner "Company.sync_all"` to pull the latest data broker companies from sources.
 6. Run `bin/rails server` to start the Rails server.

--- a/app/models/company.rb
+++ b/app/models/company.rb
@@ -61,4 +61,12 @@ class Company < ApplicationRecord
       create(website: website, **attributes)
     end
   end
+
+  # Convenience method to sync all companies from sources.
+  #
+  # @return [void]
+  def self.sync_all
+    Company.update_california_data_brokers
+    Company.update_data_brokers_watch_companies
+  end
 end

--- a/config/recurring.yml
+++ b/config/recurring.yml
@@ -1,10 +1,4 @@
-# production:
-#   periodic_cleanup:
-#     class: CleanSoftDeletedRecordsJob
-#     queue: background
-#     args: [ 1000, { batch_size: 500 } ]
-#     schedule: every hour
-#   periodic_command:
-#     command: "SoftDeletedRecord.due.delete_all"
-#     priority: 2
-#     schedule: at 5am every day
+production:
+  daily_company_sync:
+    command: "Company.sync_all"
+    schedule: every day at midnight

--- a/lib/tasks/sync_companies.rake
+++ b/lib/tasks/sync_companies.rake
@@ -1,6 +1,0 @@
-# Runs the relevant methods to update the companies table with the latest data from
-# the California Privacy Protection Agency (CPPA) and DataBrokersWatch.org.
-task sync_companies: :environment do
-  Company.update_california_data_brokers
-  Company.update_data_brokers_watch_companies
-end

--- a/test/integration/data_sync_flows_test.rb
+++ b/test/integration/data_sync_flows_test.rb
@@ -1,21 +1,10 @@
 require "test_helper"
 
 class DataSyncFlowsTest < ActionDispatch::IntegrationTest
-  test "CPPA data brokers syncable" do
+  test "all companies syncable" do
     assert_equal 1, Company.count # We start off with one fixture
 
-    Company.update_california_data_brokers
-
-    assert Company.count > 1
-    assert_equal 0, Company.where("name like ?", " %").count
-    assert_equal 0, Company.where("name like ?", "% ").count
-    assert_equal 0, Company.where("website like ?", "%www%").count
-  end
-
-  test "DataBrokersWatch.org companies syncable" do
-    assert_equal 1, Company.count # We start off with one fixture
-
-    Company.update_data_brokers_watch_companies
+    Company.sync_all
 
     assert Company.count > 1
     assert_equal 0, Company.where("name like ?", " %").count


### PR DESCRIPTION
# Overview

This makes it so that data brokers are refreshed on a daily basis at midnight via Solid Queue recurring tasks, not on a manual Rake task execution.