### PR TITLE
fix: Docker entrypoint script

### DIFF
--- a/bin/docker-entrypoint
+++ b/bin/docker-entrypoint
@@ -4,7 +4,7 @@
 # sync companies from sources.
 if [ "${1}" == "./bin/rails" ] && [ "${2}" == "server" ]; then
   ./bin/rails db:prepare
-  ./bin/rake sync_companies
+  ./bin/rails runner "Company.sync_all"
 fi
 
 exec "${@}"


### PR DESCRIPTION
# Overview

The Docker entrypoint config was trying to run an old Rake task that no longer exists, so this updates that line to run the newly working command.